### PR TITLE
Enhance README with organization profile information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # .github
 
-Meta info for the Capgemini GitHub organisation.
+Meta info for the Capgemini GitHub organisation to be displayed publicly on https://github.com/Capgemini.
+
+The profile is in `profile/README.md`
+
+There is a separate profile displayed for organisation members, managed at https://github.com/Capgemini/.github-private/blob/main/profile/README.md
+
+See https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile for more information


### PR DESCRIPTION
Added details about the Capgemini GitHub organization profile and links.